### PR TITLE
Fix pachyderm pipelines failing because of a wrong WORKER_IMAGE

### DIFF
--- a/pachyderm/templates/pachd/deployment.yaml
+++ b/pachyderm/templates/pachd/deployment.yaml
@@ -40,7 +40,7 @@ spec:
           value: /var/pachyderm/pachd
           {{ end }}
         - name: WORKER_IMAGE
-          value: "{{ .Values.pachd.image.repository }}:{{ .Values.pachd.image.tag }}"
+          value: "{{ .Values.worker.image.repository }}:{{ .Values.worker.image.tag }}"
         - name: IMAGE_PULL_SECRET
           #value:
         - name: WORKER_SIDECAR_IMAGE

--- a/pachyderm/values.yaml
+++ b/pachyderm/values.yaml
@@ -84,6 +84,11 @@ pachd:
     create: true
     name: pachyderm-worker #TODO Set default in helpers
 
+worker:
+  image:
+    repository: pachyderm/worker
+    tag: "1.11.3"
+
 etcd:
   image:
     repository: pachyderm/etcd


### PR DESCRIPTION
See the problem description in thread: https://pachyderm-users.slack.com/archives/C3UN0S0Q0/p1613760814226900

Briefly, when I create a pipeline, its `initContainer` is loaded via a wrong image:
```
initContainerStatuses:
  - containerID: docker://543c89f5b5f3a5ee8cfb0fd07c4fe875859bda563e2cb58b43b8ce3f5089116f
    image: pachyderm/pachd:1.11.3
    imageID: docker-pullable://pachyderm/pachd@sha256:ba5a875f86c6beeedfaf9f592f570ee47557a86cffd456ec6c3e5aa8502685af
    lastState:
      terminated:
        containerID: docker://543c89f5b5f3a5ee8cfb0fd07c4fe875859bda563e2cb58b43b8ce3f5089116f
        exitCode: 127
        finishedAt: "2021-02-19T18:48:32Z"
        message: 'OCI runtime create failed: container_linux.go:370: starting container
          process caused: exec: "/app/init": stat /app/init: no such file or directory:
          unknown'
        reason: ContainerCannotRun
        startedAt: "2021-02-19T18:48:32Z"
```

- wrong: `image: pachyderm/pachd:1.11.3`
- should be: `image: pachyderm/worker:1.11.3`