### PR TITLE
Grab bag

### DIFF
--- a/pachyderm/Chart.yaml
+++ b/pachyderm/Chart.yaml
@@ -20,4 +20,4 @@ version: 0.1.6
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 1.16.0
+appVersion: 1.12.4

--- a/pachyderm/templates/dash/deployment.yaml
+++ b/pachyderm/templates/dash/deployment.yaml
@@ -6,6 +6,7 @@ metadata:
     app: dash
     suite: pachyderm
   name: dash
+  namespace: {{ .Release.Namespace }}
 spec:
   selector:
     matchLabels:
@@ -18,6 +19,7 @@ spec:
         app: dash
         suite: pachyderm
       name: dash
+      namespace: {{ .Release.Namespace }}
     spec:
       containers:
       - image: "{{ .Values.dash.image.repository }}:{{ .Values.dash.image.tag }}"

--- a/pachyderm/templates/dash/deployment.yaml
+++ b/pachyderm/templates/dash/deployment.yaml
@@ -29,8 +29,8 @@ spec:
         - containerPort: 8080
           name: dash-http
         resources: {}
-      - image: pachyderm/grpc-proxy:0.4.10 #TODO 
-        imagePullPolicy: IfNotPresent #TODO
+      - image: pachyderm/grpc-proxy:0.4.10
+        imagePullPolicy: IfNotPresent
         name: grpc-proxy
         ports:
         - containerPort: 8081

--- a/pachyderm/templates/dash/service.yaml
+++ b/pachyderm/templates/dash/service.yaml
@@ -6,6 +6,7 @@ metadata:
     app: dash
     suite: pachyderm
   name: dash
+  namespace: {{ .Release.Namespace }}
 spec:
   ports:
   - name: dash-http

--- a/pachyderm/templates/etcd/headless-service.yaml
+++ b/pachyderm/templates/etcd/headless-service.yaml
@@ -6,6 +6,7 @@ metadata:
     app: etcd
     suite: pachyderm
   name: etcd-headless
+  namespace: {{ .Release.Namespace }}
 spec:
   clusterIP: None
   ports:

--- a/pachyderm/templates/etcd/service.yaml
+++ b/pachyderm/templates/etcd/service.yaml
@@ -6,6 +6,7 @@ metadata:
     app: etcd
     suite: pachyderm
   name: etcd
+  namespace: {{ .Release.Namespace }}
 spec:
   ports:
   - name: client-port

--- a/pachyderm/templates/etcd/service.yaml
+++ b/pachyderm/templates/etcd/service.yaml
@@ -11,7 +11,6 @@ spec:
   ports:
   - name: client-port
     port: 2379
-    targetPort: client-port
   selector:
     app: etcd
   type: ClusterIP

--- a/pachyderm/templates/etcd/statefulset.yaml
+++ b/pachyderm/templates/etcd/statefulset.yaml
@@ -6,6 +6,7 @@ metadata:
     app: etcd
     suite: pachyderm
   name: etcd
+  namespace: {{ .Release.Namespace }}
 spec:
   replicas: 1
   selector:
@@ -19,6 +20,7 @@ spec:
         app: etcd
         suite: pachyderm
       name: etcd
+      namespace: {{ .Release.Namespace }}
     spec:
       containers:
       - args:
@@ -65,6 +67,7 @@ spec:
         app: etcd
         suite: pachyderm
       name: etcd-storage
+      namespace: {{ .Release.Namespace }}
     spec:
       accessModes:
       - ReadWriteOnce

--- a/pachyderm/templates/etcd/statefulset.yaml
+++ b/pachyderm/templates/etcd/statefulset.yaml
@@ -51,18 +51,16 @@ spec:
           name: client-port
         - containerPort: 2380
           name: peer-port
-        resources:
-          requests: #TODO
-            cpu: "1"
-            memory: 2G
+        resources: {{- toYaml .Values.etcd.resources | nindent 10 }}
         volumeMounts:
         - mountPath: /var/data/etcd
           name: etcd-storage
-      imagePullSecrets: null #TODO
   volumeClaimTemplates:
   - metadata:
+  {{- if or (eq .Values.pachd.storage.backend "AMAZON") (eq .Values.pachd.storage.backend "GOOGLE") }}
       annotations:
-        volume.beta.kubernetes.io/storage-class: etcd-storage-class #TODO only set if storage class created
+        volume.beta.kubernetes.io/storage-class: etcd-storage-class
+  {{- end }}
       labels:
         app: etcd
         suite: pachyderm
@@ -73,4 +71,4 @@ spec:
       - ReadWriteOnce
       resources:
         requests:
-          storage: 10Gi #TODO Parameterize storage size
+          storage: {{ .Values.etcd.storageSize }}

--- a/pachyderm/templates/pachd/deployment.yaml
+++ b/pachyderm/templates/pachd/deployment.yaml
@@ -5,6 +5,7 @@ metadata:
     app: pachd
     suite: pachyderm
   name: pachd
+  namespace: {{ .Release.Namespace }}
 spec:
   replicas: 1
   selector:
@@ -22,6 +23,7 @@ spec:
         app: pachd
         suite: pachyderm
       name: pachd
+      namespace: {{ .Release.Namespace }}
     spec:
       containers:
       - command:

--- a/pachyderm/templates/pachd/deployment.yaml
+++ b/pachyderm/templates/pachd/deployment.yaml
@@ -15,10 +15,10 @@ spec:
   strategy: {}
   template:
     metadata:
-      {{ if .Values.pachd.storage.amazon.iamRole }}
+      {{- if .Values.pachd.storage.amazon.iamRole }}
       annotations:
         iam.amazonaws.com/role: {{ .Values.pachd.storage.amazon.iamRole }}
-      {{ end }}
+      {{- end }}
       labels:
         app: pachd
         suite: pachyderm
@@ -38,35 +38,35 @@ spec:
         - name: STORAGE_BACKEND
           value: {{ .Values.pachd.storage.backend }}
         - name: STORAGE_HOST_PATH
-          {{ if eq .Values.pachd.storage.backend "LOCAL" }}
+          {{- if eq .Values.pachd.storage.backend "LOCAL" }}
           value: /var/pachyderm/pachd
-          {{ end }}
+          {{- end }}
         - name: WORKER_IMAGE
           value: "{{ .Values.worker.image.repository }}:{{ .Values.worker.image.tag }}"
         - name: IMAGE_PULL_SECRET
-          #value: TODO Wire up
+          #value: TODO
         - name: WORKER_SIDECAR_IMAGE
           value: "{{ .Values.pachd.image.repository }}:{{ .Values.pachd.image.tag }}"
         - name: WORKER_IMAGE_PULL_POLICY
-          value: IfNotPresent #TODO use pachd pull policy or make separate workerPullPolicy?
+          value: IfNotPresent #TODO
         - name: WORKER_SERVICE_ACCOUNT
           value: {{ .Values.pachd.workerServiceAccount.name }}
         - name: PACHD_VERSION
           value: "{{ .Values.pachd.image.tag }}"
         - name: METRICS
           value: {{ .Values.pachd.metrics.enabled | quote }}
-        {{ if .Values.pachd.metricsEndpoint}}
+        {{- if .Values.pachd.metricsEndpoint}}
         - name: METRICS_ENDPOINT
           value: "https://{{ .Values.pachd.metricsEndpoint }}/api/v1/metrics"
-        {{ end }}
+        {{- end }}
         - name: LOG_LEVEL
           value: {{ .Values.pachd.logLevel }}
         - name: BLOCK_CACHE_BYTES
           value: {{ .Values.pachd.blockCacheBytes | quote }}
-          {{ if.Values.pachd.storage.amazon.iamRole }}
+          {{- if.Values.pachd.storage.amazon.iamRole }}
         - name: IAM_ROLE
           value: {{ .Values.pachd.storage.amazon.iamRole }}
-          {{ end }}
+          {{- end }}
         - name: NO_EXPOSE_DOCKER_SOCKET
           value: {{ .Values.pachd.noExposeDockerSocket | quote }}
         - name: PACHYDERM_AUTHENTICATION_DISABLED_FOR_TESTING
@@ -84,10 +84,10 @@ spec:
               resource: requests.memory
         - name: EXPOSE_OBJECT_API
           value: {{ .Values.pachd.exposeObjectAPI | quote }}
-        {{ if .Values.pachd.clusterDeploymentID }}
+        {{- if .Values.pachd.clusterDeploymentID }}
         - name: CLUSTER_DEPLOYMENT_ID
           value: {{ .Values.pachd.clusterDeploymentID }}
-        {{ end }}
+        {{- end }}
         - name: REQUIRE_CRITICAL_SERVERS_ONLY
           value: {{ .Values.pachd.requireCriticalServersOnly | quote }}
         - name: PACHD_POD_NAME
@@ -97,7 +97,7 @@ spec:
               fieldPath: metadata.name
         - name: PPS_WORKER_GRPC_PORT
           value: {{ .Values.pachd.ppsWorkerGRPCPort | quote }}
-        {{ if eq .Values.pachd.storage.backend "GOOGLE" }}
+        {{- if eq .Values.pachd.storage.backend "GOOGLE" }}
         - name: GOOGLE_BUCKET
           valueFrom:
             secretKeyRef:
@@ -110,8 +110,8 @@ spec:
               key: google-cred
               name: pachyderm-storage-secret
               optional: true
-        {{ end }}
-        {{ if eq .Values.pachd.storage.backend "MICROSOFT" }}
+        {{- end }}
+        {{- if eq .Values.pachd.storage.backend "MICROSOFT" }}
         - name: MICROSOFT_CONTAINER
           valueFrom:
             secretKeyRef:
@@ -130,8 +130,8 @@ spec:
               key: microsoft-secret
               name: pachyderm-storage-secret
               optional: true
-        {{ end }}
-        {{ if eq .Values.pachd.storage.backend "MINIO" }}
+        {{- end }}
+        {{- if eq .Values.pachd.storage.backend "MINIO" }}
         - name: MINIO_BUCKET
           valueFrom:
             secretKeyRef:
@@ -168,8 +168,8 @@ spec:
               key: minio-signature
               name: pachyderm-storage-secret
               optional: true
-        {{ end }}
-        {{ if eq .Values.pachd.storage.backend "AMAZON" }}
+        {{- end }}
+        {{- if eq .Values.pachd.storage.backend "AMAZON" }}
         - name: AMAZON_REGION
           valueFrom:
             secretKeyRef:
@@ -278,11 +278,19 @@ spec:
               key: no-verify-ssl
               name: pachyderm-storage-secret
               optional: true
-        {{ end }}
+        - name: OBJ_LOG_OPTS
+          valueFrom:
+            secretKeyRef:
+              key: log-options
+              name: pachyderm-storage-secret
+              optional: true
+        {{- end }}
         - name: STORAGE_UPLOAD_CONCURRENCY_LIMIT
           value: {{ .Values.pachd.storage.uploadConcurrencyLimit | quote }}
         - name: STORAGE_PUT_FILE_CONCURRENCY_LIMIT
           value: {{ .Values.pachd.storage.putFileConcurrencyLimit | quote }}
+        - name: STORAGE_V2
+          value: "false"
         image: "{{ .Values.pachd.image.repository }}:{{ .Values.pachd.image.tag }}"
         imagePullPolicy: {{ .Values.pachd.image.pullPolicy }}
         name: pachd
@@ -307,37 +315,34 @@ spec:
         - containerPort: 657
           name: oidc-port
           protocol: TCP
+        - containerPort: 656
+          name: prometheus-metrics
+          protocol: TCP
         readinessProbe:
           exec:
             command:
             - /pachd
             - --readiness
-        resources:
-          limits: #TODO
-            cpu: "1"
-            memory: 2G
-          requests: #TODO
-            cpu: "1"
-            memory: 2G
+        resources: {{- toYaml .Values.pachd.resources | nindent 10 }}
         volumeMounts:
         - mountPath: /pach
           name: pach-disk
         - mountPath: /pachyderm-storage-secret
           name: pachyderm-storage-secret
-        {{ if .Values.tls.enabled }}
+        {{- if .Values.tls.enabled }}
         - mountPath: /pachd-tls-cert
           name: pachd-tls-cert
-        {{ end }}
-      {{ if .Values.pachd.serviceAccount.name }}
+        {{- end }}
+      {{- if .Values.pachd.serviceAccount.name }}
       serviceAccountName: {{ .Values.pachd.serviceAccount.name }}
-      {{ end }}
+      {{- end }}
       volumes:
       - name: pach-disk
       - name: pachyderm-storage-secret
         secret:
           secretName: pachyderm-storage-secret
-      {{ if .Values.tls.enabled }}
+      {{- if .Values.tls.enabled }}
       - name: pachd-tls-cert
         secret:
           secretName: pachd-tls-cert
-      {{ end }}
+      {{- end }}

--- a/pachyderm/templates/pachd/peer-service.yaml
+++ b/pachyderm/templates/pachd/peer-service.yaml
@@ -5,6 +5,7 @@ metadata:
     app: pachd
     suite: pachyderm
   name: pachd-peer
+  namespace: {{ .Release.Namespace }}
 spec:
   ports:
   - name: api-grpc-peer-port

--- a/pachyderm/templates/pachd/rbac/clusterrole.yaml
+++ b/pachyderm/templates/pachd/rbac/clusterrole.yaml
@@ -1,9 +1,9 @@
 {{ if .Values.rbac.create }}
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole #TODO option to use role instead of clusterrole
+kind: ClusterRole
 metadata:
   labels:
-    app: "" #TODO
+    app: ""
     suite: pachyderm
   name: pachyderm
   namespace: {{ .Release.Namespace }}

--- a/pachyderm/templates/pachd/rbac/clusterrolebinding.yaml
+++ b/pachyderm/templates/pachd/rbac/clusterrolebinding.yaml
@@ -1,9 +1,9 @@
-{{ if .Values.rbac.create }} #TODO Check if service account name set
+{{ if .Values.rbac.create }} 
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding #TODO option to use role instead of clusterrole
+kind: ClusterRoleBinding
 metadata:
   labels:
-    app: "" #TODO
+    app: ""
     suite: pachyderm
   name: pachyderm
   namespace: {{ .Release.Namespace }}

--- a/pachyderm/templates/pachd/rbac/serviceaccount.yaml
+++ b/pachyderm/templates/pachd/rbac/serviceaccount.yaml
@@ -2,12 +2,12 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  {{ if .Values.pachd.storage.google.serviceAccountName }} 
+  {{- if .Values.pachd.storage.google.serviceAccountName }} 
   annotations:
     iam.gke.io/gcp-service-account: {{ .Values.pachd.storage.google.serviceAccountName | quote }}
-  {{ end }}
+  {{- end }}
   labels:
-    app: "" #TODO
+    app: ""
     suite: pachyderm
   name: {{ .Values.pachd.serviceAccount.name }}
   namespace: {{ .Release.Namespace }}

--- a/pachyderm/templates/pachd/rbac/worker-role.yaml
+++ b/pachyderm/templates/pachd/rbac/worker-role.yaml
@@ -3,7 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    app: "" #TODO
+    app: ""
     suite: pachyderm
   name: pachyderm-worker
   namespace: {{ .Release.Namespace }}

--- a/pachyderm/templates/pachd/rbac/worker-rolebinding.yaml
+++ b/pachyderm/templates/pachd/rbac/worker-rolebinding.yaml
@@ -1,9 +1,9 @@
-{{ if .Values.rbac.create }} #TODO Check if service account name set
+{{ if .Values.rbac.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    app: "" #TODO
+    app: ""
     suite: pachyderm
   name: pachyderm-worker
   namespace: {{ .Release.Namespace }}

--- a/pachyderm/templates/pachd/rbac/worker-serviceaccount.yaml
+++ b/pachyderm/templates/pachd/rbac/worker-serviceaccount.yaml
@@ -2,12 +2,12 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  {{ if .Values.pachd.storage.google.serviceAccountName }} 
+  {{- if .Values.pachd.storage.google.serviceAccountName }} 
   annotations:
     iam.gke.io/gcp-service-account: {{ .Values.pachd.storage.google.serviceAccountName | quote }}
-  {{ end }}
+  {{- end }}
   labels:
-    app: "" #TODO 
+    app: ""
     suite: pachyderm
   name: {{ .Values.pachd.workerServiceAccount.name }}
   namespace: {{ .Release.Namespace }}

--- a/pachyderm/templates/pachd/service.yaml
+++ b/pachyderm/templates/pachd/service.yaml
@@ -10,49 +10,61 @@ metadata:
   name: pachd
   namespace: {{ .Release.Namespace }}
 spec:
-  ports: #Port ordering so dash can access unencrypted port? (Alysha hack)
+  ports:
+  # This must remain first in the list for compatibility with old dash (can't connect when TLS enabled on api-grpc-port)
+  # The first port in the list sets the PACHD_SERVICE_PORT variable used by https://github.com/pachyderm/grpc-proxy/blob/master/Dockerfile
+  - name: api-grpc-peer
+    {{- if eq .Values.pachd.service.type "NodePort" }}
+    nodePort: 30653
+    {{- end }}
+    port: 653
+    targetPort: peer-port    
   - name: api-grpc-port
-    {{ if eq .Values.pachd.service.type "NodePort" }}
+    {{- if eq .Values.pachd.service.type "NodePort" }}
     nodePort: 30650
-    {{ end }}
+    {{- end }}
     port: 650
     targetPort: api-grpc-port
   - name: trace-port
-    {{ if eq .Values.pachd.service.type "NodePort" }}
+    {{- if eq .Values.pachd.service.type "NodePort" }}
     nodePort: 30651
-    {{ end }}
+    {{- end }}
     port: 651
     targetPort: trace-port
   - name: api-http-port
-    {{ if eq .Values.pachd.service.type "NodePort" }}
+    {{- if eq .Values.pachd.service.type "NodePort" }}
     nodePort: 30652
-    {{ end }}
+    {{- end }}
     port: 652
     targetPort: api-http-port
   - name: saml-port
-    {{ if eq .Values.pachd.service.type "NodePort" }}
+    {{- if eq .Values.pachd.service.type "NodePort" }}
     nodePort: 30654
-    {{ end }}
+    {{- end }}
     port: 654
     targetPort: saml-port
   - name: oidc-port
-    {{ if eq .Values.pachd.service.type "NodePort" }}
+    {{- if eq .Values.pachd.service.type "NodePort" }}
     nodePort: 30657
-    {{ end }}
+    {{- end }}
     port: 657
     targetPort: oidc-port
   - name: api-git-port
-    {{ if eq .Values.pachd.service.type "NodePort" }}
+    {{- if eq .Values.pachd.service.type "NodePort" }}
     nodePort: 30655
-    {{ end }}
+    {{- end }}
     port: 655
     targetPort: api-git-port
   - name: s3gateway-port
-    {{ if eq .Values.pachd.service.type "NodePort" }}
+    {{- if eq .Values.pachd.service.type "NodePort" }}
     nodePort: 30600
-    {{ end }}
+    {{- end }}
     port: 600
     targetPort: s3gateway-port
+  - name: prometheus-metrics
+    port: 656
+    protocol: TCP
+    targetPort: prometheus-metrics
   selector:
     app: pachd
   type: {{ .Values.pachd.service.type }}

--- a/pachyderm/templates/pachd/service.yaml
+++ b/pachyderm/templates/pachd/service.yaml
@@ -8,6 +8,7 @@ metadata:
     app: pachd
     suite: pachyderm
   name: pachd
+  namespace: {{ .Release.Namespace }}
 spec:
   ports: #Port ordering so dash can access unencrypted port? (Alysha hack)
   - name: api-grpc-port

--- a/pachyderm/templates/pachd/storage-secret.yaml
+++ b/pachyderm/templates/pachd/storage-secret.yaml
@@ -40,3 +40,4 @@ metadata:
     app: pachyderm-storage-secret
     suite: pachyderm
   name: pachyderm-storage-secret
+  namespace: {{ .Release.Namespace }}

--- a/pachyderm/templates/pachd/storage-secret.yaml
+++ b/pachyderm/templates/pachd/storage-secret.yaml
@@ -21,6 +21,7 @@ data:
   amazon-token: {{ .Values.pachd.storage.amazon.amazonToken | b64enc }}
   custom-endpoint: {{ .Values.pachd.storage.amazon.customEndpoint | b64enc }}
   disable-ssl: {{ .Values.pachd.storage.amazon.disableSSL | b64enc }}
+  log-options: {{ .Values.pachd.storage.amazon.logOptions | b64enc }}
   max-upload-parts: {{ .Values.pachd.storage.amazon.maxUploadParts | b64enc }}
   no-verify-ssl: {{ .Values.pachd.storage.amazon.noVerifySSL | b64enc }}
   part-size: {{ .Values.pachd.storage.amazon.partSize | b64enc }}

--- a/pachyderm/values.yaml
+++ b/pachyderm/values.yaml
@@ -1,33 +1,29 @@
 dash:
   image:
     repository: pachyderm/dash
-    tag: "0.5.48"
+    tag: "0.5.57"
     pullPolicy: IfNotPresent
-  resources: {} #TODO Wire up, default resources?
-    # We usually recommend not to specify default resources and to leave this as a conscious
-    # choice for the user. This also increases chances charts run on environments with little
-    # resources, such as Minikube. If you do want to specify resources, uncomment the following
-    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-    # limits:
-    #   cpu: 100m
-    #   memory: 128Mi
-    # requests:
-    #   cpu: 100m
-    #   memory: 128Mi
+  # resources: {} TODO
 
 pachd:
   image:
     repository: pachyderm/pachd
-    tag: "1.11.3"
+    tag: "1.12.4"
     pullPolicy: IfNotPresent
-  resources: {} #TODO Wire up
+  resources: {}
+    #limits:
+    #  cpu: "1"
+    #  memory: 2G
+    #requests:
+    #  cpu: "1"
+    #  memory: 2G  
   logLevel: info
   metrics:
     enabled: true
     endpoint: ""
   noExposeDockerSocket: false
   numShards: 16
-  blockCacheBytes: 0G
+  blockCacheBytes: 1G
   authenticationDisabledForTesting: false
   exposeObjectAPI: false
   clusterDeploymentID: ""
@@ -50,14 +46,15 @@ pachd:
       amazon-vault-token: ""
       amazonDistribution: ""
       customEndpoint: ""
-      retries: ""
-      timeout: ""
-      uploadACL: ""
-      reverse: ""
-      partSize: ""
-      maxUploadParts: ""
-      disableSSL: ""
-      noVerifySSL: ""
+      retries: "10"
+      timeout: "5m"
+      uploadACL: bucket-owner-full-control
+      reverse: "true"
+      partSize: "5242880"
+      maxUploadParts: "10000"
+      disableSSL: "false"
+      logOptions: ""
+      noVerifySSL: "false"
       iamRole: "" #TODO - ensure iam role wired up in all places
     microsoft:
       microsoftContainer: ""
@@ -73,28 +70,35 @@ pachd:
     uploadConcurrencyLimit: 100
     putFileConcurrencyLimit: 100
   service: #TODO How to handle selective ports for hub
-    type: LoadBalancer
-    apiGrpcPort:
-      expose: true
-      port: 30650
+    type: ClusterIP
+    #apiGrpcPort:
+    #  expose: true
+    #  port: 30650
   serviceAccount:
     create: true
-    name: pachyderm #TODO Set default in helpers
+    name: pachyderm #TODO Set default in helpers / Wire up in templates
   workerServiceAccount:
     create: true
-    name: pachyderm-worker #TODO Set default in helpers
+    name: pachyderm-worker #TODO Set default in helpers / Wire up in templates
 
 worker:
   image:
     repository: pachyderm/worker
-    tag: "1.11.3"
+    tag: "1.12.4"
 
 etcd:
   image:
     repository: pachyderm/etcd
     tag: "v3.3.5"
     pullPolicy: IfNotPresent
-  resources: {} #TODO Wire up
+  storageSize: 10Gi    
+  resources: {}
+    #limits:
+    #  cpu: "1"
+    #  memory: 2G
+    #requests:
+    #  cpu: "1"
+    #  memory: 2G    
 
 imageCredentials: {}
 #  registry: ""


### PR DESCRIPTION
Change pachd service default to clusterIP for security
Make resources configurable for pachd and etcd, remove configurability from dash
Update default tag to 1.12.4
Commented out unused selective ports section in values.yaml
Removed setting custom grpc-proxy version from todo
Removed target-port from etcd service (not in original manifest)
Remove TODO from imagepullsecrets in etcd
Only set etcd storage class if Amazon or Google
Parameterize Etcd storage size
Add whitespace chomping everywhere
Add prometheus metrics port (new)
Add storage v2 env var (new)
Add Obj Log Opts (new)
Added peer port to pachd service (from Hub, for compatibility with old dash)
Remove TODOs from cluster role and rolebinding (added as issue in repo)
Removed TODO on app label (leave same as old manifest for now)