### PR TITLE
force pachd-sidecar to have same version as pachd

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,39 @@
+# For emacs partials
+*~
+*#*
+
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+*.DS_Store
+
+# Architecture specific extensions/prefixes
+./*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe
+
+*.swp
+*.swo
+
+_tmp
+.bucket
+.cluster_name
+
+# python stuff
+*.pyc
+__pycache__
+

--- a/pachyderm/templates/pachd/deployment.yaml
+++ b/pachyderm/templates/pachd/deployment.yaml
@@ -42,7 +42,7 @@ spec:
           value: {{ .Values.pachd.storage.local.hostPath }}pachd
           {{- end }}
         - name: WORKER_IMAGE
-          value: "{{ .Values.worker.image.repository }}:{{ .Values.worker.image.tag }}"
+          value: "{{ .Values.worker.image.repository }}:{{ .Values.pachd.image.tag }}"
         - name: IMAGE_PULL_SECRET
           value: {{ .Values.imagePullSecret | quote }}
         - name: WORKER_SIDECAR_IMAGE

--- a/pachyderm/values.schema.json
+++ b/pachyderm/values.schema.json
@@ -407,9 +407,6 @@
                         },
                         "repository": {
                             "type": "string"
-                        },
-                        "tag": {
-                            "type": "string"
                         }
                     }
                 },

--- a/pachyderm/values.yaml
+++ b/pachyderm/values.yaml
@@ -244,7 +244,6 @@ tls:
 worker:
   image:
     repository: "pachyderm/worker"
-    tag: "1.12.4"
     pullPolicy: "IfNotPresent"
   serviceAccount:
     create: true

--- a/test/pachyderm_helm_test.go
+++ b/test/pachyderm_helm_test.go
@@ -94,7 +94,6 @@ func TestPachdImageTagDeploymentEnv(t *testing.T) {
 	options := &helm.Options{
 		SetValues: map[string]string{
 			"pachd.image.tag":             expectedTag,
-			"worker.image.tag":            expectedTag,
 			"pachd.storage.backend":       "GOOGLE",
 			"pachd.storage.google.bucket": "bucket",
 		},


### PR DESCRIPTION
Signed-off-by: echohack <git@echohack.app>

The pachd-sidecar should always have the same version as pachd. If the version does not exist in the source repository, then fail.

Also add a basic .gitignore