### PR TITLE
etcd requires 1500 IOPS to be performant with pachyderm

### DIFF
--- a/pachyderm/templates/etcd/storageclass.yaml
+++ b/pachyderm/templates/etcd/storageclass.yaml
@@ -11,7 +11,7 @@ parameters:
   type: {{ if eq .Values.pachd.storage.backend "GOOGLE" -}}
   pd-ssd
   {{- else if eq .Values.pachd.storage.backend "AMAZON" -}}
-  gp2
+  gp3
   {{- end }}
 provisioner: {{ if eq .Values.pachd.storage.backend "GOOGLE" -}}
   kubernetes.io/gce-pd

--- a/pachyderm/values.yaml
+++ b/pachyderm/values.yaml
@@ -48,7 +48,7 @@ etcd:
   # StorageClass for its storage.  It is analogous to the
   # --etcd-storage-class argument to pachctl deploy.
   storageClass: ""
-  storageSize: "10Gi"
+  storageSize: "100Gi"
   service:
     type: ClusterIP
 


### PR DESCRIPTION
Signed-off-by: echohack <git@echohack.app>

This PR changes a few options in the default values to ensure that we suggest the correct storage class and size to meet the 1500 IOPS minimum requirement for running a performant etcd cluster.