### PR TITLE
Give clear error on required value failure

### DIFF
--- a/pachyderm/templates/pachd/deployment.yaml
+++ b/pachyderm/templates/pachd/deployment.yaml
@@ -34,9 +34,9 @@ spec:
         - name: ETCD_PREFIX
           #value:
         - name: NUM_SHARDS
-          value: {{ required "number of shards missing" .Values.pachd.numShards | quote }}
+          value: {{ required ".Values.pachd.numShards is required." .Values.pachd.numShards | quote }}
         - name: STORAGE_BACKEND
-          value: {{ required "storage backend missing" .Values.pachd.storage.backend | quote }}
+          value: {{ required ".Values.pachd.storage.backend is required." .Values.pachd.storage.backend | quote }}
         - name: STORAGE_HOST_PATH
           {{- if eq .Values.pachd.storage.backend "LOCAL" }}
           value: {{ .Values.pachd.storage.local.hostPath }}pachd


### PR DESCRIPTION
Signed-off-by: echohack <git@echohack.app>

When a user is attempting to run the helm chart, not filling in a required field leads to an error as so:

`Error: execution error at (pachyderm/templates/pachd/deployment.yaml:39:20): storage backend missing`

This error is confusing for the user. The user has no idea how to fix the problem. Instead, we should tell them which value to actually fix as so:

`Error: execution error at (pachyderm/templates/pachd/deployment.yaml:39:20): .Values.pachd.storage.backend is required.`

This is a searchable string that will allow the user to fix the problem.