### PR TITLE
Fix #71

### DIFF
--- a/pachyderm/templates/pachd/storage-secret.yaml
+++ b/pachyderm/templates/pachd/storage-secret.yaml
@@ -32,7 +32,7 @@ data:
   log-options: {{ .Values.pachd.storage.amazon.logOptions | toString | b64enc | quote }}
   max-upload-parts: {{ .Values.pachd.storage.amazon.maxUploadParts | toString | b64enc | quote }}
   no-verify-ssl: {{ not .Values.pachd.storage.amazon.verifySSL | toString | b64enc | quote }}
-  part-size: {{ .Values.pachd.storage.amazon.partSize | toString | b64enc | quote }}
+  part-size: {{ .Values.pachd.storage.amazon.partSize | b64enc | quote }}
   retries: {{ .Values.pachd.storage.amazon.retries | toString | b64enc | quote }}
   reverse: {{ .Values.pachd.storage.amazon.reverse | toString | b64enc | quote }}
   timeout: {{ .Values.pachd.storage.amazon.timeout | toString | b64enc | quote }}

--- a/pachyderm/values.schema.json
+++ b/pachyderm/values.schema.json
@@ -260,7 +260,7 @@
                                     "type": "integer"
                                 },
                                 "partSize": {
-                                    "type": "integer"
+                                    "type": "string"
                                 },
                                 "region": {
                                     "type": "string"

--- a/pachyderm/values.yaml
+++ b/pachyderm/values.yaml
@@ -143,8 +143,10 @@ pachd:
       # inverse of the --no-verify-ssl argument to pachctl deploy.
       verifySSL: true
       # partSize sets the part size for object storage uploads.  It is
-      # analogous to the --part-size argument to pachctl deploy.
-      partSize: 5242880
+      # analogous to the --part-size argument to pachctl deploy.  It
+      # has to be a string due to Helm and YAML parsing integers as
+      # floats.  Cf. https://github.com/helm/helm/issues/1707
+      partSize: "5242880"
       # region sets the AWS region to use.
       region: ""
       # retries sets the number of retries for object storage

--- a/test/aws_test.go
+++ b/test/aws_test.go
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: Pachyderm, Inc. <info@pachyderm.com>
+// SPDX-License-Identifier: Apache-2.0
+
+package helmtest
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/helm"
+	v1 "k8s.io/api/core/v1"
+)
+
+func TestAWS(t *testing.T) {
+	objects, err := manifestToObjects(helm.RenderTemplate(t,
+		&helm.Options{
+			SetStrValues: map[string]string{
+				"pachd.storage.backend": "AMAZON",
+			},
+		}, "../pachyderm", "release-name", nil))
+	if err != nil {
+		t.Error(err)
+	}
+	for _, obj := range objects {
+		switch obj := obj.(type) {
+		case *v1.Secret:
+			if _, err := strconv.Atoi(string(obj.Data["part-size"])); err != nil {
+				t.Error(err)
+			}
+		}
+	}
+}


### PR DESCRIPTION
Addresses #71. Ugly, but unavoidable due to how Helm (or the YAML library Helm uses) treats larger integers.