### PR TITLE
Revert back to requiring Kubernetes 1.16.0 or higher

### DIFF
--- a/pachyderm/Chart.yaml
+++ b/pachyderm/Chart.yaml
@@ -30,6 +30,6 @@ version: 0.5.0
 # using.
 appVersion: 1.13.0
 
-kubeVersion: ">= 1.18.0-0"
+kubeVersion: ">= 1.16.0-0"
 
 icon: https://www.pachyderm.com/favicons/favicon-32x32.png


### PR DESCRIPTION
I do not think it uses any v1.18 changes yet.