### PR TITLE
Only create TLS secret if certificate and key are present

### DIFF
--- a/examples/hub-values.yaml
+++ b/examples/hub-values.yaml
@@ -53,4 +53,3 @@ pachd:
 
 tls:
   certName: "dash-tls"
-  create: null

--- a/pachyderm/templates/pachd/tls-secret.yaml
+++ b/pachyderm/templates/pachd/tls-secret.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.tls.create }}
+{{- if and .Values.tls.create .Values.tls.create.crt .Values.tls.create.key }}
 {{- /*
 SPDX-FileCopyrightText: Pachyderm, Inc. <info@pachyderm.com>
 SPDX-License-Identifier: Apache-2.0


### PR DESCRIPTION
There is more work to do here (cf. https://github.com/pachyderm/helmchart/issues/77), but this
fixes an immediate Hub deployment issue.