### PR TITLE
Add ingress object to dash to collect all ingress options

### DIFF
--- a/examples/gcp-values-tls.yaml
+++ b/examples/gcp-values-tls.yaml
@@ -2,9 +2,12 @@
 # SPDX-License-Identifier: Apache-2.0
 
 dash:
-  tls:
+  ingress:
     enabled: true
-    secretName: "pach-tls" #Will use same secret as pach
+    host: "blah.com"
+    tls:
+      enabled: true
+      secretName: "pach-tls" #Will use same secret as pach
 
 pachd:
   image:

--- a/examples/hub-values.yaml
+++ b/examples/hub-values.yaml
@@ -1,11 +1,15 @@
 dash:
   image:
     tag: "0.5.58"
-  # url is configured per workspace.
-  url: "https://dash.test/"
   tls:
     enabled: true
     secretName: "dash-tls"
+  ingress:
+    enabled: true
+    annotations:
+      kubernetes.io/ingress.class: "traefik"
+    host: "https://dash.test/"
+
 
 etcd:
   resources:

--- a/examples/hub-values.yaml
+++ b/examples/hub-values.yaml
@@ -8,8 +8,7 @@ dash:
     enabled: true
     annotations:
       kubernetes.io/ingress.class: "traefik"
-    host: "https://dash.test/"
-
+    host: "dash.test"
 
 etcd:
   resources:
@@ -59,3 +58,4 @@ pachd:
   tls:
     enabled: true
     secretName: "dash-tls"
+

--- a/examples/hub-values.yaml
+++ b/examples/hub-values.yaml
@@ -1,11 +1,11 @@
 dash:
   image:
     tag: "0.5.58"
-  tls:
-    enabled: true
-    secretName: "dash-tls"
   ingress:
     enabled: true
+    tls:
+      enabled: true
+      secretName: "dash-tls"
     annotations:
       kubernetes.io/ingress.class: "traefik"
     host: "dash.test"

--- a/pachyderm/templates/dash/ingress.yaml
+++ b/pachyderm/templates/dash/ingress.yaml
@@ -13,9 +13,9 @@ metadata:
     app: "dash"
     suite: "pachyderm"
 spec:
-  {{- if .Values.dash.tls.enabled }}
+  {{- if .Values.dash.ingress.tls.enabled }}
   tls:
-    - secretName: {{ required "if dash.tls.enabled you must specify dash.tls.secretName" .Values.dash.tls.secretName }}
+    - secretName: {{ required "if dash.ingress.tls.enabled you must specify dash.ingress.tls.secretName" .Values.dash.ingress.tls.secretName }}
   {{- end }}
   rules:
     - host: {{ required "dash.ingress.host is required when dash.ingress.enabled" .Values.dash.ingress.host | quote }}

--- a/pachyderm/templates/dash/ingress.yaml
+++ b/pachyderm/templates/dash/ingress.yaml
@@ -2,14 +2,13 @@
 SPDX-FileCopyrightText: Pachyderm, Inc. <info@pachyderm.com>
 SPDX-License-Identifier: Apache-2.0
 */ -}}
-{{- if and .Values.dash.enabled .Values.dash.url -}}
+{{- if and .Values.dash.enabled .Values.dash.ingress.enabled -}}
 apiVersion: "networking.k8s.io/v1beta1"
 kind: "Ingress"
 metadata:
   name: "dash"
+  annotations: {{ toYaml .Values.dash.annotations | nindent 4 }}
   namespace: {{ .Release.Namespace }}
-  annotations:
-    kubernetes.io/ingress.class: "traefik"
   labels:
     app: "dash"
     suite: "pachyderm"
@@ -19,7 +18,7 @@ spec:
     - secretName: {{ required "if dash.tls.enabled you must specify dash.tls.secretName" .Values.dash.tls.secretName }}
   {{- end }}
   rules:
-    - host: {{ .Values.dash.url | quote }}
+    - host: {{ required "dash.ingress.host is required when dash.ingress.enabled" .Values.dash.ingress.host | quote }}
       http:
         paths:
           - path: "/"

--- a/pachyderm/templates/dash/tls-secret.yaml
+++ b/pachyderm/templates/dash/tls-secret.yaml
@@ -3,23 +3,23 @@ SPDX-FileCopyrightText: Pachyderm, Inc. <info@pachyderm.com>
 SPDX-License-Identifier: Apache-2.0
 */ -}}
 {{- /* Sanity check to ensure .create set if .crt or .key set  */ -}}
-{{- if and (not .Values.dash.tls.newSecret.create) .Values.dash.tls.newSecret.crt }}
-  {{ fail "Must set dash.tls.newSecret.create to true when specifying dash.tls.newSecret.crt "}}
+{{- if and (not .Values.dash.ingress.tls.newSecret.create) .Values.dash.ingress.tls.newSecret.crt }}
+  {{ fail "Must set dash.ingress.tls.newSecret.create to true when specifying dash.ingress.tls.newSecret.crt "}}
 {{ end -}}
-{{- if and (not .Values.dash.tls.newSecret.create) .Values.dash.tls.newSecret.key }}
-  {{ fail "Must set dash.tls.newSecret.create to true when specifying dash.tls.newSecret.key "}}
+{{- if and (not .Values.dash.ingress.tls.newSecret.create) .Values.dash.ingress.tls.newSecret.key }}
+  {{ fail "Must set dash.ingress.tls.newSecret.create to true when specifying dash.ingress.tls.newSecret.key "}}
 {{ end -}}
 {{- if .Values.dash.enabled -}}
-{{- if and .Values.dash.tls.enabled .Values.dash.tls.newSecret.create }}
+{{- if and .Values.dash.ingress.tls.enabled .Values.dash.ingress.tls.newSecret.create }}
 apiVersion: "v1"
 data:
-  tls.crt: {{ required "If dash.tls.newSecret.create, you must specify a cert at dash.tls.newSecret.crt" .Values.dash.tls.newSecret.crt | b64enc | quote }}
-  tls.key: {{ required "If dash.tls.newSecret.create, you must specify a key at dash.tls.newSecret.key" .Values.dash.tls.newSecret.key | b64enc | quote }}
+  tls.crt: {{ required "If dash.ingress.tls.newSecret.create, you must specify a cert at dash.ingress.tls.newSecret.crt" .Values.dash.ingress.tls.newSecret.crt | b64enc | quote }}
+  tls.key: {{ required "If dash.ingress.tls.newSecret.create, you must specify a key at dash.ingress.tls.newSecret.key" .Values.dash.ingress.tls.newSecret.key | b64enc | quote }}
 kind: Secret
 metadata:
   labels:
     app: "dash"
     suite: "pachyderm"
-  name: {{ required "When dash.tls.enabled you must specify dash.tls.secretName" .Values.dash.tls.secretName | quote }}
+  name: {{ required "When dash.ingress.tls.enabled you must specify dash.ingress.tls.secretName" .Values.dash.ingress.tls.secretName | quote }}
 {{ end -}}
 {{ end -}}

--- a/pachyderm/values.schema.json
+++ b/pachyderm/values.schema.json
@@ -22,6 +22,20 @@
                         }
                     }
                 },
+                "ingress": {
+                    "type": "object",
+                    "properties": {
+                        "annotations": {
+                            "type": "object"
+                        },
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "host": {
+                            "type": "string"
+                        }
+                    }
+                },
                 "podLabels": {
                     "type": "object"
                 },
@@ -63,9 +77,6 @@
                             "type": "string"
                         }
                     }
-                },
-                "url": {
-                    "type": "string"
                 }
             }
         },

--- a/pachyderm/values.schema.json
+++ b/pachyderm/values.schema.json
@@ -33,6 +33,31 @@
                         },
                         "host": {
                             "type": "string"
+                        },
+                        "tls": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean"
+                                },
+                                "newSecret": {
+                                    "type": "object",
+                                    "properties": {
+                                        "create": {
+                                            "type": "boolean"
+                                        },
+                                        "crt": {
+                                            "type": "string"
+                                        },
+                                        "key": {
+                                            "type": "string"
+                                        }
+                                    }
+                                },
+                                "secretName": {
+                                    "type": "string"
+                                }
+                            }
                         }
                     }
                 },
@@ -49,31 +74,6 @@
                             "type": "object"
                         },
                         "type": {
-                            "type": "string"
-                        }
-                    }
-                },
-                "tls": {
-                    "type": "object",
-                    "properties": {
-                        "enabled": {
-                            "type": "boolean"
-                        },
-                        "newSecret": {
-                            "type": "object",
-                            "properties": {
-                                "create": {
-                                    "type": "boolean"
-                                },
-                                "crt": {
-                                    "type": "string"
-                                },
-                                "key": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "secretName": {
                             "type": "string"
                         }
                     }

--- a/pachyderm/values.yaml
+++ b/pachyderm/values.yaml
@@ -38,24 +38,23 @@ dash:
     enabled: false
     annotations: {}
     host: ""
-    #TODO Move TLS
+    # There are three options for TLS:
+    # 1. Disabled
+    # 2. Enabled, existingSecret, specify secret name
+    # 3. Enabled, newSecret, must specify cert, key, secretName and set newSecret.create to true
+    tls:
+      enabled: false
+      secretName: ""
+      newSecret:
+        create: false
+        crt: ""
+        key: ""
 
   service:
     # labels specifies labels to add to the dash service.
     labels: {}
     # type specifies the Kubernetes type of the dash service.
     type: ClusterIP
-  # There are three options for TLS:
-  # 1. Disabled
-  # 2. Enabled, existingSecret, specify secret name
-  # 3. Enabled, newSecret, must specify cert, key, secretName and set newSecret.create to true
-  tls:
-    enabled: false
-    secretName: ""
-    newSecret:
-      create: false
-      crt: ""
-      key: ""
 
 etcd:
   affinity: {}

--- a/pachyderm/values.yaml
+++ b/pachyderm/values.yaml
@@ -34,6 +34,12 @@ dash:
     #requests:
     #  cpu: "1"
     #  memory: "2G"
+  ingress:
+    enabled: false
+    annotations: {}
+    host: ""
+    #TODO Move TLS
+
   service:
     # labels specifies labels to add to the dash service.
     labels: {}
@@ -50,11 +56,6 @@ dash:
       create: false
       crt: ""
       key: ""
-  # url specifies the URL of the dash ingress, used as the host value
-  # of a rule.
-  url: ""
-
-
 
 etcd:
   affinity: {}

--- a/test/global_test.go
+++ b/test/global_test.go
@@ -135,3 +135,13 @@ func ensureVolumePresent(matchVol v1.Volume, volumes []v1.Volume) bool {
 	}
 	return present
 }
+
+// GetContainerByName returns container or nil
+func GetContainerByName(name string, containers []v1.Container) (*v1.Container, bool) {
+	for _, c := range containers {
+		if c.Name == name {
+			return &c, true
+		}
+	}
+	return &v1.Container{}, false
+}

--- a/test/hub_test.go
+++ b/test/hub_test.go
@@ -38,7 +38,7 @@ func TestHub(t *testing.T) {
 		switch object := object.(type) {
 		case *v1beta1.Ingress:
 			for _, rule := range object.Spec.Rules {
-				if rule.Host == "https://dash.test/" {
+				if rule.Host == "dash.test" {
 					checks["ingress"] = true
 				}
 			}

--- a/test/tls_test.go
+++ b/test/tls_test.go
@@ -72,9 +72,9 @@ func TestEnableDashTLSNoName(t *testing.T) {
 	helmChartPath := "../pachyderm"
 	options := &helm.Options{
 		SetValues: map[string]string{
-			"pachd.storage.backend": "LOCAL",
-			"dash.tls.enabled":      "true",
-			"dash.ingress.host":     "http://blah.com",
+			"pachd.storage.backend":    "LOCAL",
+			"dash.ingress.tls.enabled": "true",
+			"dash.ingress.host":        "http://blah.com",
 		},
 	}
 
@@ -88,11 +88,11 @@ func TestEnableDashTLSExistingSecret(t *testing.T) {
 	helmChartPath := "../pachyderm"
 	options := &helm.Options{
 		SetValues: map[string]string{
-			"pachd.storage.backend": "LOCAL",
-			"dash.tls.enabled":      "true",
-			"dash.tls.secretName":   "blah",
-			"dash.ingress.enabled":  "true",
-			"dash.ingress.host":     "http://blah.com",
+			"pachd.storage.backend":       "LOCAL",
+			"dash.ingress.tls.enabled":    "true",
+			"dash.ingress.tls.secretName": "blah",
+			"dash.ingress.enabled":        "true",
+			"dash.ingress.host":           "http://blah.com",
 		},
 	}
 
@@ -116,9 +116,9 @@ func TestDashTLSNewSecretNoEnable(t *testing.T) {
 	helmChartPath := "../pachyderm"
 	options := &helm.Options{
 		SetValues: map[string]string{
-			"pachd.storage.backend":  "LOCAL",
-			"dash.tls.newSecret.crt": "blah",
-			"dash.ingress.host":      "http://blah.com",
+			"pachd.storage.backend":          "LOCAL",
+			"dash.ingress.tls.newSecret.crt": "blah",
+			"dash.ingress.host":              "http://blah.com",
 		},
 	}
 

--- a/test/tls_test.go
+++ b/test/tls_test.go
@@ -25,11 +25,12 @@ func TestEnablePachTLSNoName(t *testing.T) {
 }
 
 func TestEnablePachTLSExistingSecret(t *testing.T) {
+	expectedSecretName := "blah"
 	options := &helm.Options{
 		SetValues: map[string]string{
 			"pachd.storage.backend": "LOCAL",
 			"pachd.tls.enabled":     "true",
-			"pachd.tls.secretName":  "blah",
+			"pachd.tls.secretName":  expectedSecretName,
 		},
 	}
 	templates := []string{"templates/pachd/deployment.yaml"}
@@ -56,7 +57,7 @@ func TestEnablePachTLSExistingSecret(t *testing.T) {
 	wantVol := v1.Volume{
 		VolumeSource: v1.VolumeSource{
 			Secret: &v1.SecretVolumeSource{
-				SecretName: "blah",
+				SecretName: expectedSecretName,
 			},
 		},
 		Name: "pachd-tls-cert",
@@ -86,11 +87,12 @@ func TestEnableDashTLSNoName(t *testing.T) {
 
 func TestEnableDashTLSExistingSecret(t *testing.T) {
 	helmChartPath := "../pachyderm"
+	expectedSecretName := "blah"
 	options := &helm.Options{
 		SetValues: map[string]string{
 			"pachd.storage.backend":       "LOCAL",
 			"dash.ingress.tls.enabled":    "true",
-			"dash.ingress.tls.secretName": "blah",
+			"dash.ingress.tls.secretName": expectedSecretName,
 			"dash.ingress.enabled":        "true",
 			"dash.ingress.host":           "http://blah.com",
 		},
@@ -102,12 +104,12 @@ func TestEnableDashTLSExistingSecret(t *testing.T) {
 	helm.UnmarshalK8SYaml(t, output, &ingress)
 	found := false
 	for _, t := range ingress.Spec.TLS {
-		if t.SecretName == "blah" {
+		if t.SecretName == expectedSecretName {
 			found = true
 		}
 	}
 	if !found {
-		t.Errorf("TLS Secret not in ingress")
+		t.Errorf("Expected TLS Secret not in ingress")
 	}
 
 }


### PR DESCRIPTION
Add explicit option to disable ingress, ingress disabled by default
Change URL to HOST to match ingress language
Make annotations configurable
Add explicit namespace to dash ingress

Combine with https://github.com/pachyderm/helmchart/pull/81 once it ships

Closes: https://github.com/pachyderm/helmchart/issues/67 
Closes: https://github.com/pachyderm/helmchart/issues/63
Closes: https://github.com/pachyderm/helmchart/issues/62

Implementation note: We want to move ingress to the root for v2 as ingress encompasses both dash and pach