### PR TITLE
Change resources requests and limits to opt in vs opt out

### DIFF
--- a/examples/hub-values.yaml
+++ b/examples/hub-values.yaml
@@ -1,7 +1,6 @@
 dash:
   image:
     tag: "0.5.58"
-  resources: null
   # url is configured per workspace.
   url: "https://dash.test/"
 
@@ -10,7 +9,6 @@ etcd:
     requests:
       cpu: "1"
       memory: 2G
-    limits: null
   service:
     annotations:
       prometheus.io/port: "2379"

--- a/examples/local-dev-values.yaml
+++ b/examples/local-dev-values.yaml
@@ -24,7 +24,6 @@ pachd:
 
 
 dash:
-  resources: null
   service:
     type: NodePort
 

--- a/pachyderm/values.schema.json
+++ b/pachyderm/values.schema.json
@@ -23,31 +23,7 @@
                     }
                 },
                 "resources": {
-                    "type": "object",
-                    "properties": {
-                        "limits": {
-                            "type": "object",
-                            "properties": {
-                                "cpu": {
-                                    "type": "string"
-                                },
-                                "memory": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "requests": {
-                            "type": "object",
-                            "properties": {
-                                "cpu": {
-                                    "type": "string"
-                                },
-                                "memory": {
-                                    "type": "string"
-                                }
-                            }
-                        }
-                    }
+                    "type": "object"
                 },
                 "service": {
                     "type": "object",
@@ -83,31 +59,7 @@
                     }
                 },
                 "resources": {
-                    "type": "object",
-                    "properties": {
-                        "limits": {
-                            "type": "object",
-                            "properties": {
-                                "cpu": {
-                                    "type": "string"
-                                },
-                                "memory": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "requests": {
-                            "type": "object",
-                            "properties": {
-                                "cpu": {
-                                    "type": "string"
-                                },
-                                "memory": {
-                                    "type": "string"
-                                }
-                            }
-                        }
-                    }
+                    "type": "object"
                 },
                 "service": {
                     "type": "object",
@@ -201,31 +153,7 @@
                     "type": "boolean"
                 },
                 "resources": {
-                    "type": "object",
-                    "properties": {
-                        "limits": {
-                            "type": "object",
-                            "properties": {
-                                "cpu": {
-                                    "type": "string"
-                                },
-                                "memory": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "requests": {
-                            "type": "object",
-                            "properties": {
-                                "cpu": {
-                                    "type": "string"
-                                },
-                                "memory": {
-                                    "type": "string"
-                                }
-                            }
-                        }
-                    }
+                    "type": "object"
                 },
                 "service": {
                     "type": "object",

--- a/pachyderm/values.yaml
+++ b/pachyderm/values.yaml
@@ -24,7 +24,7 @@ dash:
     # tag is the image repo to pull from; together with repository it
     # replicates the --dash-image argument to pachctl deploy.
     tag: "0.5.57"
-  # resources specifies the resource request and limits
+  # resources specifies the resource request and limits.
   resources: {}
     #limits:
     #  cpu: "1"

--- a/pachyderm/values.yaml
+++ b/pachyderm/values.yaml
@@ -24,14 +24,14 @@ dash:
     # tag is the image repo to pull from; together with repository it
     # replicates the --dash-image argument to pachctl deploy.
     tag: "0.5.57"
-  # resources specifies the resource request
-  resources: #Can't zero out resources with {}
-    limits:
-      cpu: "1"
-      memory: "2G"
-    requests:
-      cpu: "1"
-      memory: "2G"
+  # resources specifies the resource request and limits
+  resources: {}
+    #limits:
+    #  cpu: "1"
+    #  memory: "2G"
+    #requests:
+    #  cpu: "1"
+    #  memory: "2G"
   service:
     # type specifies the Kubernetes type of the dash service.
     type: ClusterIP
@@ -48,14 +48,14 @@ etcd:
     repository: "pachyderm/etcd"
     tag: "v3.3.5"
     pullPolicy: "IfNotPresent"
-  # resources specifies the resource request
-  resources:
-    limits:
-      cpu: "1"
-      memory: "2G"
-    requests:
-      cpu: "1"
-      memory: "2G"
+  # resources specifies the resource request and limits
+  resources: {}
+    #limits:
+    #  cpu: "1"
+    #  memory: "2G"
+    #requests:
+    #  cpu: "1"
+    #  memory: "2G"
   # storageClass indicates the etcd should use an existing
   # StorageClass for its storage.  It is analogous to the
   # --etcd-storage-class argument to pachctl deploy.
@@ -104,14 +104,14 @@ pachd:
   # performance.  It is analogous to the --shards argument to pachctl
   # deploy.
   numShards: 16
-  # resources specifies the resource request.
-  resources:
-    limits:
-      cpu: "1"
-      memory: "2G"
-    requests:
-      cpu: "1"
-      memory: "2G"
+  # resources specifies the resource requests and limits
+  resources: {}
+    #limits:
+    #  cpu: "1"
+    #  memory: "2G"
+    #requests:
+    #  cpu: "1"
+    #  memory: "2G"
   # requireCriticalServersOnly only requires the critical pachd
   # servers to startup and run without errors.  It is analogous to the
   # --require-critical-servers-only argument to pachctl deploy.


### PR DESCRIPTION
This is somewhat controversial, but the more I think about it, we should have resources (especially limits) be opt in vs opt out. There's some hard edges around the use of resource limits and implicitly adding them is becoming bad practice. Unfortunately we lose the json schema validation, but with good docs in values.yaml (and resource blocks like this being very standard in helm charts) I think we're ok making an exception.