### PR TITLE
add required storage class for Azure example

### DIFF
--- a/examples/microsoft-values.yaml
+++ b/examples/microsoft-values.yaml
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: Pachyderm, Inc. <info@pachyderm.com>
 # SPDX-License-Identifier: Apache-2.0
-
+etcd:
+  storageClass: "default"
 pachd:
   storage:
     backend: "MICROSOFT"

--- a/examples/microsoft-values.yaml
+++ b/examples/microsoft-values.yaml
@@ -1,7 +1,6 @@
 # SPDX-FileCopyrightText: Pachyderm, Inc. <info@pachyderm.com>
 # SPDX-License-Identifier: Apache-2.0
-etcd:
-  storageClass: "default"
+
 pachd:
   storage:
     backend: "MICROSOFT"

--- a/pachyderm/templates/etcd/statefulset.yaml
+++ b/pachyderm/templates/etcd/statefulset.yaml
@@ -76,7 +76,7 @@ spec:
   {{- if not (eq .Values.pachd.storage.backend "LOCAL") }}
   volumeClaimTemplates:
   - metadata:
-  {{- if or (eq .Values.pachd.storage.backend "AMAZON") (eq .Values.pachd.storage.backend "GOOGLE") }}
+  {{- if or (eq .Values.pachd.storage.backend "AMAZON") (eq .Values.pachd.storage.backend "GOOGLE") (eq .Values.pachd.storage.backend "MICROSOFT")}}
       annotations:
         volume.beta.kubernetes.io/storage-class: {{ if .Values.etcd.storageClass -}}
         {{ .Values.etcd.storageClass }}

--- a/pachyderm/templates/etcd/statefulset.yaml
+++ b/pachyderm/templates/etcd/statefulset.yaml
@@ -94,5 +94,13 @@ spec:
       - ReadWriteOnce
       resources:
         requests:
-          storage: {{ .Values.etcd.storageSize }}
+        storage: {{ if and (eq .Values.etcd.storageSize  "100Gi") (eq .Values.pachd.storage.backend "MICROSOFT") -}}
+            256Gi
+            {{- /*
+            Azure Disk IOPs are by size. 256Gi provisions 1,100 IOPs
+            */ -}}
+            {{- else -}}
+            {{ .Values.etcd.storageSize }}
+            {{- end }}
+          
   {{- end }}

--- a/pachyderm/templates/etcd/statefulset.yaml
+++ b/pachyderm/templates/etcd/statefulset.yaml
@@ -94,13 +94,13 @@ spec:
       - ReadWriteOnce
       resources:
         requests:
-        storage: {{ if and (eq .Values.etcd.storageSize  "100Gi") (eq .Values.pachd.storage.backend "MICROSOFT") -}}
-            256Gi
-            {{- /*
-            Azure Disk IOPs are by size. 256Gi provisions 1,100 IOPs
-            */ -}}
-            {{- else -}}
-            {{ .Values.etcd.storageSize }}
-            {{- end }}
+          storage: {{ if and (eq .Values.etcd.storageSize  "100Gi") (eq .Values.pachd.storage.backend "MICROSOFT") -}}
+              256Gi
+              {{- /*
+              Azure Disk IOPs are by size. 256Gi provisions 1,100 IOPs
+              */ -}}
+              {{- else -}}
+              {{ .Values.etcd.storageSize }}
+              {{- end }}
           
   {{- end }}

--- a/pachyderm/templates/etcd/statefulset.yaml
+++ b/pachyderm/templates/etcd/statefulset.yaml
@@ -94,12 +94,13 @@ spec:
       - ReadWriteOnce
       resources:
         requests:
-          storage: {{ if and (eq .Values.etcd.storageSize  "100Gi") (eq .Values.pachd.storage.backend "MICROSOFT") -}}
+          storage: {{ if not .Values.etcd.storageSize  -}}
+              {{ if eq .Values.pachd.storage.backend "MICROSOFT" -}}
               256Gi
-              {{- /*
-              Azure Disk IOPs are by size. 256Gi provisions 1,100 IOPs
-              */ -}}
               {{- else -}}
+              100Gi
+              {{- end }}
+              {{ else -}}
               {{ .Values.etcd.storageSize }}
               {{- end }}
           

--- a/pachyderm/templates/etcd/storageclass.yaml
+++ b/pachyderm/templates/etcd/storageclass.yaml
@@ -12,14 +12,19 @@ metadata:
     suite: pachyderm
   name: etcd-storage-class
 parameters:
-  type: {{ if eq .Values.pachd.storage.backend "GOOGLE" -}}
-  pd-ssd
+  {{ if eq .Values.pachd.storage.backend "GOOGLE" -}}
+  type: pd-ssd
   {{- else if eq .Values.pachd.storage.backend "AMAZON" -}}
-  gp3
+  type: gp3
+  {{- else if eq .Values.pachd.storage.backend "MICROSOFT" -}}
+  storageaccounttype: Premium_LRS
+  kind: Managed
   {{- end }}
 provisioner: {{ if eq .Values.pachd.storage.backend "GOOGLE" -}}
   kubernetes.io/gce-pd
   {{- else if eq .Values.pachd.storage.backend "AMAZON" -}}
   kubernetes.io/aws-ebs
+  {{- else if eq .Values.pachd.storage.backend "MICROSOFT" -}}
+  kubernetes.io/azure-disk
   {{- end }}
 {{ end -}}

--- a/pachyderm/templates/etcd/storageclass.yaml
+++ b/pachyderm/templates/etcd/storageclass.yaml
@@ -2,7 +2,7 @@
 SPDX-FileCopyrightText: Pachyderm, Inc. <info@pachyderm.com>
 SPDX-License-Identifier: Apache-2.0
 */ -}}
-{{- if not (or .Values.etcd.storageClass (eq .Values.pachd.storage.backend "LOCAL" )) -}}
+{{- if or (eq .Values.pachd.storage.backend "AMAZON") (eq .Values.pachd.storage.backend "GOOGLE") (eq .Values.pachd.storage.backend "MICROSOFT")}}
 allowVolumeExpansion: true
 apiVersion: storage.k8s.io/v1
 kind: StorageClass

--- a/pachyderm/templates/etcd/storageclass.yaml
+++ b/pachyderm/templates/etcd/storageclass.yaml
@@ -3,6 +3,7 @@ SPDX-FileCopyrightText: Pachyderm, Inc. <info@pachyderm.com>
 SPDX-License-Identifier: Apache-2.0
 */ -}}
 {{- if or (eq .Values.pachd.storage.backend "AMAZON") (eq .Values.pachd.storage.backend "GOOGLE") (eq .Values.pachd.storage.backend "MICROSOFT")}}
+{{- if not .Values.etcd.storageClass -}}
 allowVolumeExpansion: true
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
@@ -27,4 +28,5 @@ provisioner: {{ if eq .Values.pachd.storage.backend "GOOGLE" -}}
   {{- else if eq .Values.pachd.storage.backend "MICROSOFT" -}}
   kubernetes.io/azure-disk
   {{- end }}
+{{ end -}}
 {{ end -}}

--- a/pachyderm/values.yaml
+++ b/pachyderm/values.yaml
@@ -74,7 +74,8 @@ etcd:
   # --etcd-storage-class argument to pachctl deploy.
   storageClass: ""
   # storageSize specifies the size of the volume to use for etcd.
-  storageSize: "100Gi"
+  # If you do not specify, it will default to 256Gi on Azure and 100Gi on GCP/AWS
+  storageSize: ""
   service:
     # annotations specifies annotations to add to the etcd service.
     annotations: {}

--- a/test/microsoft_test.go
+++ b/test/microsoft_test.go
@@ -21,7 +21,6 @@ func TestMicrosoft(t *testing.T) {
 			&helm.Options{
 				SetStrValues: map[string]string{
 					"pachd.storage.backend":             "MICROSOFT",
-					"etcd.storage.backend":              "MICROSOFT",
 					"pachd.storage.microsoft.container": container,
 					"pachd.storage.microsoft.id":        id,
 					"pachd.storage.microsoft.secret":    secret,


### PR DESCRIPTION
Without a StorageClass provisioner for Azure, this sets the storage class to the default for etcd in AKS