### PR TITLE
missing name

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Create a `values.yaml` file with your storage provider of choice, and other opti
 
 ```shell
 $ helm repo add pach https://pachyderm.github.io/helmchart
-$ helm install pach/pachyderm -f values.yaml
+$ helm install pachd pach/pachyderm -f values.yaml
 ```
 
 ## Developer Guide


### PR DESCRIPTION
Error: must either provide a name or specify --generate-name