### PR TITLE
Reconcile environment variables

### DIFF
--- a/examples/hub-values.yaml
+++ b/examples/hub-values.yaml
@@ -34,7 +34,6 @@ pachd:
     ssl: "disable"
     user: "postgres"
     password: "Example-Password"
-  exposeDockerSocket: true
   goMaxProcs: 3
   # image.tag is configured per workspace.
   lokiLogging: true

--- a/examples/local-dev-values.yaml
+++ b/examples/local-dev-values.yaml
@@ -13,7 +13,6 @@ pachd:
     type: NodePort
   metrics:
     enabled: false
-  exposeDockerSocket: true
 
 dash:
   enabled: false

--- a/pachyderm/templates/pachd/deployment.yaml
+++ b/pachyderm/templates/pachd/deployment.yaml
@@ -56,7 +56,7 @@ spec:
           value: {{ .Values.pachd.postgresql.user | quote}}
         {{- end }}
         {{- if .Values.pachd.postgresql.ssl }}
-        - name: POSTGRES_SERVICE_SSL
+        - name: POSTGRES_SSL
           value: {{ .Values.pachd.postgresql.ssl | quote }}
         {{- end}}
         - name: LOKI_LOGGING
@@ -93,8 +93,6 @@ spec:
         {{- end }}
         - name: LOG_LEVEL
           value: {{ .Values.pachd.logLevel }}
-        - name: NO_EXPOSE_DOCKER_SOCKET
-          value: {{ .Values.pachd.exposeDockerSocket | not | quote }}
         - name: PACH_NAMESPACE
           valueFrom:
             fieldRef:

--- a/pachyderm/values.schema.json
+++ b/pachyderm/values.schema.json
@@ -236,9 +236,6 @@
                 "enabled": {
                     "type": "boolean"
                 },
-                "exposeDockerSocket": {
-                    "type": "boolean"
-                },
                 "goMaxProcs": {
                     "type": "integer"
                 },

--- a/pachyderm/values.yaml
+++ b/pachyderm/values.yaml
@@ -138,10 +138,6 @@ pachd:
   affinity: {}
   # clusterDeploymentID sets the Pachyderm cluster ID.
   clusterDeploymentID: ""
-  # exposeDockerSocket controls whether the Docker socket is
-  # exposed.  It is the inverse of the --no-expose-docker-socket
-  # argument passed to pachctl deploy.
-  exposeDockerSocket: false
   # goMaxProcs is passed as GOMAXPROCS to the pachd container.
   goMaxProcs: 0
   image:

--- a/test/hub_test.go
+++ b/test/hub_test.go
@@ -21,7 +21,6 @@ func TestHub(t *testing.T) {
 			"dash limits":            false,
 			"etcd limits":            false,
 			"loki logging":           false,
-			"docker socket":          false,
 			"postgres host":          false,
 			"pachd service type":     false,
 			"etcd prometheus port":   false,
@@ -66,11 +65,6 @@ func TestHub(t *testing.T) {
 								t.Error("Loki logging should be enabled")
 							}
 							checks["loki logging"] = true
-						case "NO_EXPOSE_DOCKER_SOCKET":
-							if v.Value != "false" {
-								t.Error("Docker socket should be exposed")
-							}
-							checks["docker socket"] = true
 						case "POSTGRES_HOST":
 							if v.Value != "169.254.169.254" {
 								t.Error("Postgres Host should be set")


### PR DESCRIPTION
 - Remove NO_EXPOSE_DOCKER_SOCKET.
 - Rename POSTGRES_SERVICE_SSL to POSTGRES_SSL.